### PR TITLE
[Repactor] Change Damagable Logic + Fixed Prefabs (Enemy, Player)

### DIFF
--- a/Assets/01_CJM_EnemyAndStageManager/Prefabs/Characters/Enemy_Boss.prefab
+++ b/Assets/01_CJM_EnemyAndStageManager/Prefabs/Characters/Enemy_Boss.prefab
@@ -261,6 +261,7 @@ GameObject:
   - component: {fileID: 5511726576476268746}
   - component: {fileID: 6973302235425650030}
   - component: {fileID: 9049426727235110441}
+  - component: {fileID: 9202132164485232367}
   m_Layer: 8
   m_Name: Tank_Enemy
   m_TagString: Enemy
@@ -332,6 +333,19 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1.7150676, y: 1.928067, z: 2.0766687}
   m_Center: {x: -0.007606983, y: 0.92045915, z: -0.020482242}
+--- !u!114 &9202132164485232367
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1716098769644430485}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb16f5c3562c5244c90cdcaecddbf8c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 0
 --- !u!1 &2696966804512784325
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/01_CJM_EnemyAndStageManager/Prefabs/Characters/Enemy_Elite.prefab
+++ b/Assets/01_CJM_EnemyAndStageManager/Prefabs/Characters/Enemy_Elite.prefab
@@ -95,6 +95,7 @@ GameObject:
   - component: {fileID: 8529340622530738747}
   - component: {fileID: 4470396668531051983}
   - component: {fileID: 4379929165135611614}
+  - component: {fileID: 6310342443227196642}
   m_Layer: 8
   m_Name: Tank_Enemy
   m_TagString: Enemy
@@ -166,6 +167,18 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1.7150676, y: 1.928067, z: 2.0766687}
   m_Center: {x: -0.007606983, y: 0.92045915, z: -0.020482242}
+--- !u!114 &6310342443227196642
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 424922721640109797}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb16f5c3562c5244c90cdcaecddbf8c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1367844635911128325
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/01_CJM_EnemyAndStageManager/Prefabs/Characters/Enemy_Nomal.prefab
+++ b/Assets/01_CJM_EnemyAndStageManager/Prefabs/Characters/Enemy_Nomal.prefab
@@ -95,6 +95,7 @@ GameObject:
   - component: {fileID: 4280612653482161513}
   - component: {fileID: 7911406577448185950}
   - component: {fileID: 8919381119681167022}
+  - component: {fileID: 5274994311798254800}
   m_Layer: 8
   m_Name: Tank_Enemy
   m_TagString: Enemy
@@ -166,6 +167,18 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1.7150676, y: 1.928067, z: 2.0766687}
   m_Center: {x: -0.007606983, y: 0.92045915, z: -0.020482242}
+--- !u!114 &5274994311798254800
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2643534120117538486}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb16f5c3562c5244c90cdcaecddbf8c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2836778503951367998
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/01_CJM_EnemyAndStageManager/Prefabs/Characters/Player.prefab
+++ b/Assets/01_CJM_EnemyAndStageManager/Prefabs/Characters/Player.prefab
@@ -1015,6 +1015,8 @@ GameObject:
   m_Component:
   - component: {fileID: 5076279542650503230}
   - component: {fileID: 104600375010340102}
+  - component: {fileID: 5615957175037534299}
+  - component: {fileID: 6076600127358095373}
   m_Layer: 7
   m_Name: Grade01
   m_TagString: Untagged
@@ -1062,6 +1064,37 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1.7150676, y: 1.928067, z: 2.0766687}
   m_Center: {x: -0.007606983, y: 0.92045915, z: -0.020482242}
+--- !u!114 &5615957175037534299
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3652254510068264056}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb16f5c3562c5244c90cdcaecddbf8c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 1
+--- !u!114 &6076600127358095373
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3652254510068264056}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5fea29bb7c508c244a1f805a5fd3fc4d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  outlineMode: 0
+  outlineColor: {r: 0, g: 0.9218221, b: 1, a: 1}
+  outlineWidth: 8
+  precomputeOutline: 0
+  bakeKeys: []
+  bakeValues: []
 --- !u!1 &3803318087352604204
 GameObject:
   m_ObjectHideFlags: 0
@@ -1324,6 +1357,8 @@ GameObject:
   - component: {fileID: 8027754877926174397}
   - component: {fileID: 1450063888894356612}
   - component: {fileID: 4209452293808471160}
+  - component: {fileID: 2079039164594826245}
+  - component: {fileID: 454600933015858726}
   m_Layer: 7
   m_Name: Tank_Player
   m_TagString: Player
@@ -1390,6 +1425,66 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 112
   m_CollisionDetection: 0
+--- !u!23 &2079039164594826245
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3971663193078741131}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &454600933015858726
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3971663193078741131}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5fea29bb7c508c244a1f805a5fd3fc4d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  outlineMode: 2
+  outlineColor: {r: 0, g: 0.5730128, b: 1, a: 1}
+  outlineWidth: 7.7
+  precomputeOutline: 0
+  bakeKeys: []
+  bakeValues: []
 --- !u!1 &3976995876216540381
 GameObject:
   m_ObjectHideFlags: 0
@@ -2253,6 +2348,8 @@ GameObject:
   m_Component:
   - component: {fileID: 5383680074318615244}
   - component: {fileID: 5008178582172635393}
+  - component: {fileID: 6115670209549851302}
+  - component: {fileID: 938316531574622855}
   m_Layer: 7
   m_Name: Grade02
   m_TagString: Untagged
@@ -2300,6 +2397,37 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 2.0151832, y: 1.928067, z: 2.1610763}
   m_Center: {x: 0.0017715693, y: 0.92045915, z: -0.04392898}
+--- !u!114 &6115670209549851302
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4939876263636758364}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb16f5c3562c5244c90cdcaecddbf8c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 1
+--- !u!114 &938316531574622855
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4939876263636758364}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5fea29bb7c508c244a1f805a5fd3fc4d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  outlineMode: 0
+  outlineColor: {r: 0, g: 0.9218221, b: 1, a: 1}
+  outlineWidth: 8
+  precomputeOutline: 0
+  bakeKeys: []
+  bakeValues: []
 --- !u!1 &4992939944904562137
 GameObject:
   m_ObjectHideFlags: 0
@@ -2310,6 +2438,8 @@ GameObject:
   m_Component:
   - component: {fileID: 193067934250225967}
   - component: {fileID: 8124318384675678357}
+  - component: {fileID: 5632609407546622560}
+  - component: {fileID: 7403760602725464744}
   m_Layer: 7
   m_Name: Grade04
   m_TagString: Untagged
@@ -2355,6 +2485,37 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 2.2377892, y: 1.928067, z: 2.7985303}
   m_Center: {x: -0.014128864, y: 0.92045915, z: -0.121329665}
+--- !u!114 &5632609407546622560
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4992939944904562137}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb16f5c3562c5244c90cdcaecddbf8c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 1
+--- !u!114 &7403760602725464744
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4992939944904562137}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5fea29bb7c508c244a1f805a5fd3fc4d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  outlineMode: 0
+  outlineColor: {r: 0, g: 0.9218221, b: 1, a: 1}
+  outlineWidth: 8
+  precomputeOutline: 0
+  bakeKeys: []
+  bakeValues: []
 --- !u!1 &5263898056853613081
 GameObject:
   m_ObjectHideFlags: 0
@@ -2448,6 +2609,8 @@ GameObject:
   m_Component:
   - component: {fileID: 1754246802556439196}
   - component: {fileID: 8885000233485529257}
+  - component: {fileID: 8209811584039785405}
+  - component: {fileID: 621011240232434376}
   m_Layer: 7
   m_Name: Grade03
   m_TagString: Untagged
@@ -2492,6 +2655,37 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 2.0151832, y: 1.928067, z: 2.4934568}
   m_Center: {x: 0.0017715693, y: 0.92045915, z: -0.17846394}
+--- !u!114 &8209811584039785405
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5635096437236246006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bb16f5c3562c5244c90cdcaecddbf8c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 1
+--- !u!114 &621011240232434376
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5635096437236246006}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5fea29bb7c508c244a1f805a5fd3fc4d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  outlineMode: 0
+  outlineColor: {r: 0, g: 0.9218221, b: 1, a: 1}
+  outlineWidth: 8
+  precomputeOutline: 0
+  bakeKeys: []
+  bakeValues: []
 --- !u!1 &5642617698873142493
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/01_CJM_EnemyAndStageManager/Prefabs/Entities/RespawnPoint.prefab
+++ b/Assets/01_CJM_EnemyAndStageManager/Prefabs/Entities/RespawnPoint.prefab
@@ -44,4 +44,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c436aae1d78cbde40820698fc4915d88, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  respawnFBX_Prefab: {fileID: 1624714524768532, guid: 2d3de2b4682158944b27f76db5f8a556, type: 3}
+  respawnFBX_Prefab: {fileID: 1624714524768532, guid: c9eb15264aa6c4348b00d5b9b3daab2a, type: 3}

--- a/Assets/01_CJM_EnemyAndStageManager/Scenes/CJM_ProtoType-TestScene.unity
+++ b/Assets/01_CJM_EnemyAndStageManager/Scenes/CJM_ProtoType-TestScene.unity
@@ -1,0 +1,11295 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1830542
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1830543}
+  m_Layer: 0
+  m_Name: Walls
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1830543
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1830542}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 619591397}
+  - {fileID: 340744803}
+  - {fileID: 2043449653}
+  - {fileID: 421206670}
+  - {fileID: 2063818298}
+  - {fileID: 608592864}
+  m_Father: {fileID: 86917355}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5485742 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5485744
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5485742}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7607076 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7607078
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7607076}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &12147869 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &12147871
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 12147869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &14603206 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &14603211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 14603206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &15471684 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &15471686
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 15471684}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &19901552 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &19901554
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 19901552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &20572977 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &20572982
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 20572977}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &26956694 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &26956696
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 26956694}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &38297139 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &38297141
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 38297139}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &39841988 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &39841990
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 39841988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &39969927 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &39969929
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 39969927}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &45324381
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1830543}
+    m_Modifications:
+    - target: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Name
+      value: Cube (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.58324414
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.74769
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.990034
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.0025624118
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9999967
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -180.294
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 421206666}
+    - targetCorrespondingSourceObject: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 100487670}
+    - targetCorrespondingSourceObject: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 226026842}
+    - targetCorrespondingSourceObject: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1804384840}
+    - targetCorrespondingSourceObject: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1227275640}
+    - targetCorrespondingSourceObject: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1334374573}
+    - targetCorrespondingSourceObject: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2144548913}
+    - targetCorrespondingSourceObject: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1647838724}
+    - targetCorrespondingSourceObject: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1968078034}
+    - targetCorrespondingSourceObject: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2097790036}
+    - targetCorrespondingSourceObject: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5485744}
+    - targetCorrespondingSourceObject: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1145726320}
+    - targetCorrespondingSourceObject: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2089715765}
+    - targetCorrespondingSourceObject: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 916027339}
+    - targetCorrespondingSourceObject: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1069509711}
+    - targetCorrespondingSourceObject: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1284415044}
+    - targetCorrespondingSourceObject: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 12147871}
+    - targetCorrespondingSourceObject: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 70366146}
+    - targetCorrespondingSourceObject: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 256872889}
+    - targetCorrespondingSourceObject: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1232118115}
+    - targetCorrespondingSourceObject: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 756359994}
+    - targetCorrespondingSourceObject: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 868681306}
+    - targetCorrespondingSourceObject: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 654053546}
+    - targetCorrespondingSourceObject: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1408691967}
+    - targetCorrespondingSourceObject: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 611796841}
+    - targetCorrespondingSourceObject: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1687041029}
+    - targetCorrespondingSourceObject: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1168509730}
+    - targetCorrespondingSourceObject: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 384574289}
+    - targetCorrespondingSourceObject: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 38297141}
+    - targetCorrespondingSourceObject: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1656251963}
+    - targetCorrespondingSourceObject: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1581366019}
+    - targetCorrespondingSourceObject: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1826557434}
+    - targetCorrespondingSourceObject: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1542941947}
+    - targetCorrespondingSourceObject: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1285430133}
+    - targetCorrespondingSourceObject: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 198651751}
+    - targetCorrespondingSourceObject: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 179811612}
+    - targetCorrespondingSourceObject: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1169836187}
+    - targetCorrespondingSourceObject: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1125159881}
+    - targetCorrespondingSourceObject: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1056436933}
+    - targetCorrespondingSourceObject: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 515518213}
+    - targetCorrespondingSourceObject: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 899049285}
+    - targetCorrespondingSourceObject: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 67099832}
+    - targetCorrespondingSourceObject: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7607078}
+    - targetCorrespondingSourceObject: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1603174701}
+    - targetCorrespondingSourceObject: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1987581168}
+    - targetCorrespondingSourceObject: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 930521053}
+    - targetCorrespondingSourceObject: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1724333140}
+    - targetCorrespondingSourceObject: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1694086352}
+  m_SourcePrefab: {fileID: 100100000, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+--- !u!1 &49415259 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &49415261
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 49415259}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &56131054 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &56131056
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 56131054}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &56232174 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &56232176
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 56232174}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &67099830 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &67099832
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 67099830}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &70366144 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &70366146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 70366144}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &71629816 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &71629818
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 71629816}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &73036135
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 73036136}
+  - component: {fileID: 73036140}
+  - component: {fileID: 73036139}
+  - component: {fileID: 73036138}
+  - component: {fileID: 73036137}
+  m_Layer: 0
+  m_Name: Tree_02_A_green
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &73036136
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 73036135}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.5787945, y: 0, z: -3.9094086}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 375386724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &73036137
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 73036135}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &73036138
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 73036135}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: 0adf1ff9496797245b6cc3f171aef4d7, type: 3}
+--- !u!23 &73036139
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 73036135}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &73036140
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 73036135}
+  m_Mesh: {fileID: 4300000, guid: 0adf1ff9496797245b6cc3f171aef4d7, type: 3}
+--- !u!1 &86917354
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 86917355}
+  m_Layer: 0
+  m_Name: Structure
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &86917355
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 86917354}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1073528565}
+  - {fileID: 1830543}
+  - {fileID: 727712894}
+  - {fileID: 1383522170}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &92228311
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 92228312}
+  - component: {fileID: 92228316}
+  - component: {fileID: 92228315}
+  - component: {fileID: 92228314}
+  - component: {fileID: 92228313}
+  m_Layer: 0
+  m_Name: Tree_01C_green
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &92228312
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 92228311}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -1.5384417, y: 0.12575848, z: -2.449257}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 375386724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &92228313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 92228311}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &92228314
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 92228311}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: 21a3ee2ce2de7304981687f9d4b8dd9a, type: 3}
+--- !u!23 &92228315
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 92228311}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &92228316
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 92228311}
+  m_Mesh: {fileID: 4300000, guid: 21a3ee2ce2de7304981687f9d4b8dd9a, type: 3}
+--- !u!1 &100487668 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &100487670
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 100487668}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &103420446 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &103420451
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 103420446}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &105162783 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &105162788
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 105162783}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &109317920 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &109317922
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 109317920}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &113062989 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &113062991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 113062989}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &113497845 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &113497850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 113497845}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &114653802 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &114653804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 114653802}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &116927225 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &116927227
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 116927225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &131656969
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 131656970}
+  - component: {fileID: 131656974}
+  - component: {fileID: 131656973}
+  - component: {fileID: 131656972}
+  - component: {fileID: 131656971}
+  m_Layer: 0
+  m_Name: Tree_02_B_green
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &131656970
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 131656969}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.6631045, y: 0, z: -7.7676315}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1359557739}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &131656971
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 131656969}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &131656972
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 131656969}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: 26b246f8ba86fd34d89320b44c78e2d5, type: 3}
+--- !u!23 &131656973
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 131656969}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &131656974
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 131656969}
+  m_Mesh: {fileID: 4300000, guid: 26b246f8ba86fd34d89320b44c78e2d5, type: 3}
+--- !u!1 &133524420 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &133524425
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 133524420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &135299586
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 215797797137420060, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+      propertyPath: m_Name
+      value: RespawnPoint
+      objectReference: {fileID: 0}
+    - target: {fileID: 8679250007648254164, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8679250007648254164, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8679250007648254164, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8679250007648254164, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8679250007648254164, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8679250007648254164, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8679250007648254164, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8679250007648254164, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8679250007648254164, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8679250007648254164, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+--- !u!1001 &136177994
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1064279168}
+    m_Modifications:
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3424341070634194018, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Nomal (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3424341070634194018, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+--- !u!4 &136177995 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+  m_PrefabInstance: {fileID: 136177994}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &137605656 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &137605661
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 137605656}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &137689831
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1383522170}
+    m_Modifications:
+    - target: {fileID: 8753660031007213736, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_Name
+      value: ToonWater - Water - Solid 800Tris (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.100000024
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 18.92
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+--- !u!1 &144328336 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &144328338
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 144328336}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &152893802 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &152893804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 152893802}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &155999778
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 155999779}
+  - component: {fileID: 155999783}
+  - component: {fileID: 155999782}
+  - component: {fileID: 155999781}
+  - component: {fileID: 155999780}
+  m_Layer: 0
+  m_Name: Tree_02_C_green (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &155999779
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 155999778}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1359557739}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &155999780
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 155999778}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &155999781
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 155999778}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: a65af00dd0d50914597a9d60ca2b6c9f, type: 3}
+--- !u!23 &155999782
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 155999778}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &155999783
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 155999778}
+  m_Mesh: {fileID: 4300000, guid: a65af00dd0d50914597a9d60ca2b6c9f, type: 3}
+--- !u!1 &168441520 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &168441522
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 168441520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &173166956
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 173166957}
+  - component: {fileID: 173166961}
+  - component: {fileID: 173166960}
+  - component: {fileID: 173166959}
+  - component: {fileID: 173166958}
+  m_Layer: 0
+  m_Name: Tree_01D_green
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &173166957
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 173166956}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.33080435, y: 0.17176831, z: -6.586467}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1359557739}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &173166958
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 173166956}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &173166959
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 173166956}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: c0988f2117c5ceb429e19c5075769dde, type: 3}
+--- !u!23 &173166960
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 173166956}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &173166961
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 173166956}
+  m_Mesh: {fileID: 4300000, guid: c0988f2117c5ceb429e19c5075769dde, type: 3}
+--- !u!1 &177335060 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &177335062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 177335060}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &179811610 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &179811612
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 179811610}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &198651749 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &198651751
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 198651749}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &201220577 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &201220579
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 201220577}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &201517048 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &201517050
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 201517048}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &202533512 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &202533514
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 202533512}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &211253438 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &211253440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 211253438}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &216202183
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1064279168}
+    m_Modifications:
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3424341070634194018, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Nomal
+      objectReference: {fileID: 0}
+    - target: {fileID: 3424341070634194018, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+--- !u!4 &216202184 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+  m_PrefabInstance: {fileID: 216202183}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &217738220 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &217738222
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 217738220}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &220526734 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &220526736
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 220526734}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &226026840 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &226026842
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 226026840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &228153642 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &228153647
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 228153642}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &236876467 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &236876469
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 236876467}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &237870174
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 237870175}
+  - component: {fileID: 237870178}
+  - component: {fileID: 237870177}
+  - component: {fileID: 237870176}
+  m_Layer: 0
+  m_Name: Ground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &237870175
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 237870174}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.5, z: 0}
+  m_LocalScale: {x: 50, y: 1, z: 50}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1073528565}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &237870176
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 237870174}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &237870177
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 237870174}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 4b4b25f923792ce4ab819907a4629058, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &237870178
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 237870174}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &244226512 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &244226514
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 244226512}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &250981184 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &250981186
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 250981184}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &251899188 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &251899193
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 251899188}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &256872887 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &256872889
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 256872887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &267116273
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 732578495}
+    m_Modifications:
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3424341070634194018, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Nomal (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3424341070634194018, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+--- !u!4 &267116274 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+  m_PrefabInstance: {fileID: 267116273}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &268745204 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &268745206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 268745204}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &273418946 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &273418948
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 273418946}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &278408974 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &278408976
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 278408974}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &289862197
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 289862198}
+  m_Layer: 0
+  m_Name: -------------------Camera------------------------------------ (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &289862198
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 289862197}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -25.952244, y: -1.6384783, z: 12.257519}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &292331241 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &292331246
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 292331241}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &294486614 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &294486616
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 294486614}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &300600300 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &300600305
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 300600300}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &320072707 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &320072709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 320072707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &336677111 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &336677113
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 336677111}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &339861250 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &339861252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 339861250}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &340744798 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &340744799
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 340744798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &340744803 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &345588948 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &345588950
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 345588948}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &348908957 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &348908959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 348908957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &355910976 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &355910978
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 355910976}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &359142071 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &359142076
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 359142071}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &366121161 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &366121163
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 366121161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &366217379 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &366217384
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 366217379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &366238161 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &366238166
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 366238161}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &370590320 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &370590322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 370590320}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &371328097 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &371328099
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 371328097}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &375386721
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 375386724}
+  - component: {fileID: 375386723}
+  - component: {fileID: 375386722}
+  m_Layer: 0
+  m_Name: Bush (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!54 &375386722
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 375386721}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!64 &375386723
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 375386721}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 0}
+--- !u!4 &375386724
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 375386721}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.000000021855694, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -12.92, y: 0, z: 6.38}
+  m_LocalScale: {x: 0.4055907, y: 0.5944337, z: 0.42303768}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 993094771}
+  - {fileID: 73036136}
+  - {fileID: 751900844}
+  - {fileID: 92228312}
+  - {fileID: 1817862600}
+  - {fileID: 1947961114}
+  - {fileID: 1454368007}
+  m_Father: {fileID: 727712894}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &384574287 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &384574289
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 384574287}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &387930811 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &387930813
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 387930811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &405706206 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &405706208
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 405706206}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &409427508
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 409427509}
+  - component: {fileID: 409427513}
+  - component: {fileID: 409427512}
+  - component: {fileID: 409427511}
+  - component: {fileID: 409427510}
+  m_Layer: 0
+  m_Name: Tree_02_A_green
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &409427509
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409427508}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.5787945, y: 0, z: -3.9094086}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1359557739}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &409427510
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409427508}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &409427511
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409427508}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: 0adf1ff9496797245b6cc3f171aef4d7, type: 3}
+--- !u!23 &409427512
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409427508}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &409427513
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409427508}
+  m_Mesh: {fileID: 4300000, guid: 0adf1ff9496797245b6cc3f171aef4d7, type: 3}
+--- !u!1 &420117846 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &420117848
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 420117846}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &421206665 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &421206666
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 421206665}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &421206670 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &425844089 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &425844091
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 425844089}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &426295419 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &426295421
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 426295419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &436608702 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &436608704
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 436608702}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &447259178 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &447259180
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 447259178}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &448357958 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &448357960
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 448357958}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &453827224 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &453827226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 453827224}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &457636757 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &457636759
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 457636757}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &459247438
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1830543}
+    m_Modifications:
+    - target: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Name
+      value: Cube
+      objectReference: {fileID: 0}
+    - target: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.58324414
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.74
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 15.49
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.0025624118
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9999967
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -180.294
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 619591393}
+    - targetCorrespondingSourceObject: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 828272405}
+    - targetCorrespondingSourceObject: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2004079144}
+    - targetCorrespondingSourceObject: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 576422266}
+    - targetCorrespondingSourceObject: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1416440034}
+    - targetCorrespondingSourceObject: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 972021914}
+    - targetCorrespondingSourceObject: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 359142076}
+    - targetCorrespondingSourceObject: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 14603211}
+    - targetCorrespondingSourceObject: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 564762826}
+    - targetCorrespondingSourceObject: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 133524425}
+    - targetCorrespondingSourceObject: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 137605661}
+    - targetCorrespondingSourceObject: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1591734596}
+    - targetCorrespondingSourceObject: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 724674923}
+    - targetCorrespondingSourceObject: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 822598112}
+    - targetCorrespondingSourceObject: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 103420451}
+    - targetCorrespondingSourceObject: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 292331246}
+    - targetCorrespondingSourceObject: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1841226316}
+    - targetCorrespondingSourceObject: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 366238166}
+    - targetCorrespondingSourceObject: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1491728138}
+    - targetCorrespondingSourceObject: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2077290443}
+    - targetCorrespondingSourceObject: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 747275036}
+    - targetCorrespondingSourceObject: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 677164449}
+    - targetCorrespondingSourceObject: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1047772457}
+    - targetCorrespondingSourceObject: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 833410105}
+    - targetCorrespondingSourceObject: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1864198630}
+    - targetCorrespondingSourceObject: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1334523461}
+    - targetCorrespondingSourceObject: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1823240095}
+    - targetCorrespondingSourceObject: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2119440238}
+    - targetCorrespondingSourceObject: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1001611445}
+    - targetCorrespondingSourceObject: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 105162788}
+    - targetCorrespondingSourceObject: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 251899193}
+    - targetCorrespondingSourceObject: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1223797362}
+    - targetCorrespondingSourceObject: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1344121578}
+    - targetCorrespondingSourceObject: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2069778966}
+    - targetCorrespondingSourceObject: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 300600305}
+    - targetCorrespondingSourceObject: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 113497850}
+    - targetCorrespondingSourceObject: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 798007045}
+    - targetCorrespondingSourceObject: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2041736586}
+    - targetCorrespondingSourceObject: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1051009911}
+    - targetCorrespondingSourceObject: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1879780902}
+    - targetCorrespondingSourceObject: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 943573295}
+    - targetCorrespondingSourceObject: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 228153647}
+    - targetCorrespondingSourceObject: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 20572982}
+    - targetCorrespondingSourceObject: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 940449287}
+    - targetCorrespondingSourceObject: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 366217384}
+    - targetCorrespondingSourceObject: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1079611047}
+    - targetCorrespondingSourceObject: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1567399011}
+    - targetCorrespondingSourceObject: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1751692269}
+  m_SourcePrefab: {fileID: 100100000, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+--- !u!1 &461893772 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &461893774
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 461893772}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &464123731 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &464123733
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464123731}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &465112849 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &465112851
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 465112849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &476898567 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &476898569
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 476898567}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &489129112 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &489129114
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 489129112}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &489151520 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &489151522
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 489151520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &490486336
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4049020879464840221, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.0208492
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049020879464840221, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049020879464840221, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.0323195
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049020879464840221, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049020879464840221, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049020879464840221, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049020879464840221, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049020879464840221, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049020879464840221, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4049020879464840221, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5882837748649778195, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+      propertyPath: respawnPoint
+      value: 
+      objectReference: {fileID: 1510791360}
+    - target: {fileID: 6624871158282443342, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 39dd5286107615645b1860a71bb2f9c5, type: 3}
+--- !u!1 &496433314 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &496433316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 496433314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &515518211 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &515518213
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 515518211}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &521044214 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+  m_PrefabInstance: {fileID: 2507980923612088714}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &529359642 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &529359644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 529359642}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &564762821 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &564762826
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 564762821}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &576422261 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &576422266
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 576422261}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &586059379 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &586059381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 586059379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &586918735 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &586918737
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 586918735}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &597641508 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &597641510
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 597641508}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &606724849 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &606724851
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 606724849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &606879450 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &606879452
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 606879450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &608592859 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &608592860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 608592859}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &608592864 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &609362694 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &609362696
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 609362694}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &611796839 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &611796841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 611796839}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &619591388 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &619591393
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 619591388}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &619591397 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &640304340
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3300749540816814337, guid: 64fbef0e852b251449696696b0cd5af3, type: 3}
+      propertyPath: m_Name
+      value: StageData
+      objectReference: {fileID: 0}
+    - target: {fileID: 6325053148005216482, guid: 64fbef0e852b251449696696b0cd5af3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.2452497
+      objectReference: {fileID: 0}
+    - target: {fileID: 6325053148005216482, guid: 64fbef0e852b251449696696b0cd5af3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.91934365
+      objectReference: {fileID: 0}
+    - target: {fileID: 6325053148005216482, guid: 64fbef0e852b251449696696b0cd5af3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.25483516
+      objectReference: {fileID: 0}
+    - target: {fileID: 6325053148005216482, guid: 64fbef0e852b251449696696b0cd5af3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6325053148005216482, guid: 64fbef0e852b251449696696b0cd5af3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6325053148005216482, guid: 64fbef0e852b251449696696b0cd5af3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6325053148005216482, guid: 64fbef0e852b251449696696b0cd5af3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6325053148005216482, guid: 64fbef0e852b251449696696b0cd5af3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6325053148005216482, guid: 64fbef0e852b251449696696b0cd5af3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6325053148005216482, guid: 64fbef0e852b251449696696b0cd5af3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 64fbef0e852b251449696696b0cd5af3, type: 3}
+--- !u!1 &654053544 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &654053546
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 654053544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &655319961 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &655319963
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 655319961}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &662640548 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &662640550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 662640548}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &676908585 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &676908587
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 676908585}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &677164444 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &677164449
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 677164444}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &680445070 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &680445072
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 680445070}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &681259406 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &681259408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 681259406}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &684079341 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &684079343
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 684079341}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &686619904 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &686619906
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 686619904}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &724674918 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &724674923
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 724674918}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &727712893
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 727712894}
+  m_Layer: 0
+  m_Name: Bushes
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &727712894
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 727712893}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 375386724}
+  - {fileID: 1359557739}
+  - {fileID: 1545075228}
+  m_Father: {fileID: 86917355}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &732578494
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.87
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.57
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4819136882676850808, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: state
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4819136882676850808, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: standByTimeToSpawn.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4819136882676850808, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: standByTimeToSpawn.Array.data[0]
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4819136882676850808, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: standByTimeToSpawn.Array.data[1]
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4819136882676850808, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: standByTimeToSpawn.Array.data[2]
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 7475879142699254628, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_Name
+      value: EnemySpawner
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 3051756840367345086, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1705123480}
+    - targetCorrespondingSourceObject: {fileID: 3051756840367345086, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 750573073}
+    - targetCorrespondingSourceObject: {fileID: 3051756840367345086, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 267116274}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+--- !u!4 &732578495 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3051756840367345086, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+  m_PrefabInstance: {fileID: 732578494}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &747275031 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &747275036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 747275031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &750573072
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 732578495}
+    m_Modifications:
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3424341070634194018, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Nomal (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3424341070634194018, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+--- !u!4 &750573073 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+  m_PrefabInstance: {fileID: 750573072}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &751900843
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 751900844}
+  - component: {fileID: 751900848}
+  - component: {fileID: 751900847}
+  - component: {fileID: 751900846}
+  - component: {fileID: 751900845}
+  m_Layer: 0
+  m_Name: Tree_02_B_green
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &751900844
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 751900843}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.6631045, y: 0, z: -7.7676315}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 375386724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &751900845
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 751900843}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &751900846
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 751900843}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: 26b246f8ba86fd34d89320b44c78e2d5, type: 3}
+--- !u!23 &751900847
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 751900843}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &751900848
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 751900843}
+  m_Mesh: {fileID: 4300000, guid: 26b246f8ba86fd34d89320b44c78e2d5, type: 3}
+--- !u!1 &756359992 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &756359994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 756359992}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &778460766 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &778460768
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 778460766}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &794295618 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &794295620
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 794295618}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &798007040 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &798007045
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 798007040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &808513579 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &808513581
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808513579}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &822598107 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &822598112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 822598107}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &822607995 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &822607997
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 822607995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &828272400 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &828272405
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 828272400}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &833410100 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &833410105
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 833410100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &844969852
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2878476232528589979, guid: 8956e7550160fd54ab62d11333e06e85, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.969604
+      objectReference: {fileID: 0}
+    - target: {fileID: 2878476232528589979, guid: 8956e7550160fd54ab62d11333e06e85, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.041803785
+      objectReference: {fileID: 0}
+    - target: {fileID: 2878476232528589979, guid: 8956e7550160fd54ab62d11333e06e85, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.7711866
+      objectReference: {fileID: 0}
+    - target: {fileID: 2878476232528589979, guid: 8956e7550160fd54ab62d11333e06e85, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2878476232528589979, guid: 8956e7550160fd54ab62d11333e06e85, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2878476232528589979, guid: 8956e7550160fd54ab62d11333e06e85, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2878476232528589979, guid: 8956e7550160fd54ab62d11333e06e85, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2878476232528589979, guid: 8956e7550160fd54ab62d11333e06e85, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2878476232528589979, guid: 8956e7550160fd54ab62d11333e06e85, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2878476232528589979, guid: 8956e7550160fd54ab62d11333e06e85, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5861139134137603829, guid: 8956e7550160fd54ab62d11333e06e85, type: 3}
+      propertyPath: m_Name
+      value: EnemyManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8956e7550160fd54ab62d11333e06e85, type: 3}
+--- !u!1 &868681304 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &868681306
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 868681304}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &891083717 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &891083719
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 891083717}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &899049283 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &899049285
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 899049283}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &905757903
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3876659326526126017, guid: 171ebb5c539efe449abc4faa280f4440, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.2452497
+      objectReference: {fileID: 0}
+    - target: {fileID: 3876659326526126017, guid: 171ebb5c539efe449abc4faa280f4440, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.91934365
+      objectReference: {fileID: 0}
+    - target: {fileID: 3876659326526126017, guid: 171ebb5c539efe449abc4faa280f4440, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.25483516
+      objectReference: {fileID: 0}
+    - target: {fileID: 3876659326526126017, guid: 171ebb5c539efe449abc4faa280f4440, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3876659326526126017, guid: 171ebb5c539efe449abc4faa280f4440, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3876659326526126017, guid: 171ebb5c539efe449abc4faa280f4440, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3876659326526126017, guid: 171ebb5c539efe449abc4faa280f4440, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3876659326526126017, guid: 171ebb5c539efe449abc4faa280f4440, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3876659326526126017, guid: 171ebb5c539efe449abc4faa280f4440, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3876659326526126017, guid: 171ebb5c539efe449abc4faa280f4440, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8234328357337897197, guid: 171ebb5c539efe449abc4faa280f4440, type: 3}
+      propertyPath: m_Name
+      value: StageManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 171ebb5c539efe449abc4faa280f4440, type: 3}
+--- !u!1 &908584377 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &908584379
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 908584377}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &916027337 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &916027339
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 916027337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &930521051 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &930521053
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 930521051}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &940449282 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &940449287
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 940449282}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &943573290 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &943573295
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 943573290}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &944469398 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &944469400
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944469398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &945686794 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &945686796
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 945686794}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &964436538 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &964436540
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 964436538}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &968996775
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 968996776}
+  m_Layer: 0
+  m_Name: Props
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &968996776
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 968996775}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -25.952244, y: -1.6384783, z: 12.257519}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &972021909 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &972021914
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 972021909}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &975791742 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &975791744
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975791742}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &993094770
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 993094771}
+  - component: {fileID: 993094775}
+  - component: {fileID: 993094774}
+  - component: {fileID: 993094773}
+  - component: {fileID: 993094772}
+  m_Layer: 0
+  m_Name: Tree_01D_green
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &993094771
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993094770}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.33080435, y: 0.17176831, z: -6.586467}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 375386724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &993094772
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993094770}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &993094773
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993094770}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: c0988f2117c5ceb429e19c5075769dde, type: 3}
+--- !u!23 &993094774
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993094770}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &993094775
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 993094770}
+  m_Mesh: {fileID: 4300000, guid: c0988f2117c5ceb429e19c5075769dde, type: 3}
+--- !u!1 &1001611440 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1001611445
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001611440}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1005789508 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1005789510
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1005789508}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1012641263 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1012641265
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1012641263}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1016390323 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1016390325
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1016390323}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1020362962 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1020362964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1020362962}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1032074059 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1032074061
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1032074059}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1039133499 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1039133501
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1039133499}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1041165219 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1041165221
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1041165219}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1042154316 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1042154318
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1042154316}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1047771935 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1047771937
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1047771935}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1047772452 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1047772457
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1047772452}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1051009906 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1051009911
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1051009906}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1054737037 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1054737039
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1054737037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1056436931 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1056436933
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1056436931}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1064279167
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20.42
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.7677965
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4819136882676850808, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: standByTimeToSpawn.Array.size
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4819136882676850808, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: standByTimeToSpawn.Array.data[0]
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4819136882676850808, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: standByTimeToSpawn.Array.data[1]
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4819136882676850808, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: standByTimeToSpawn.Array.data[2]
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7475879142699254628, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_Name
+      value: EnemySpawner (2)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 3051756840367345086, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 216202184}
+    - targetCorrespondingSourceObject: {fileID: 3051756840367345086, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1361825544}
+    - targetCorrespondingSourceObject: {fileID: 3051756840367345086, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 136177995}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+--- !u!4 &1064279168 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3051756840367345086, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+  m_PrefabInstance: {fileID: 1064279167}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1069509709 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1069509711
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1069509709}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1073528564
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1073528565}
+  m_Layer: 0
+  m_Name: Grounds
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1073528565
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1073528564}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 237870175}
+  m_Father: {fileID: 86917355}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1077291461 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1077291463
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1077291461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1079611042 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1079611047
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1079611042}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1091589895 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1091589897
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1091589895}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1096514245 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1096514247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1096514245}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1104505217 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1104505219
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1104505217}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1125159879 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1125159881
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1125159879}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1134478285 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1134478287
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1134478285}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1140824661 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1140824663
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1140824661}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1145726318 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1145726320
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1145726318}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1152598419 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1152598421
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1152598419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1168509728 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1168509730
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1168509728}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1169836185 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1169836187
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1169836185}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1176286880 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1176286882
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1176286880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1177283798 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1177283800
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1177283798}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1195454621 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1195454623
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1195454621}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1199489279 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1199489281
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1199489279}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1208004375 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1208004377
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1208004375}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1215683860 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1215683862
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1215683860}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1223797357 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1223797362
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1223797357}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1227275638 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1227275640
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1227275638}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1229211281 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1229211283
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1229211281}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1232118113 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1232118115
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1232118113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1234459496 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1234459498
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1234459496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1249553221
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1249553222}
+  - component: {fileID: 1249553226}
+  - component: {fileID: 1249553225}
+  - component: {fileID: 1249553224}
+  - component: {fileID: 1249553223}
+  m_Layer: 0
+  m_Name: Tree_02_C_green
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1249553222
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1249553221}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.7063348, y: 0, z: -3.3075886}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1359557739}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1249553223
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1249553221}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &1249553224
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1249553221}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: a65af00dd0d50914597a9d60ca2b6c9f, type: 3}
+--- !u!23 &1249553225
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1249553221}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1249553226
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1249553221}
+  m_Mesh: {fileID: 4300000, guid: a65af00dd0d50914597a9d60ca2b6c9f, type: 3}
+--- !u!1 &1260188705 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1260188707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1260188705}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1277443950
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.389597
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -19.21
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1465201699911725185, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4819136882676850808, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: standByTimeToSpawn.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4819136882676850808, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: standByTimeToSpawn.Array.data[0]
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 4819136882676850808, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: standByTimeToSpawn.Array.data[1]
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 7475879142699254628, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      propertyPath: m_Name
+      value: EnemySpawner (1)
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 3051756840367345086, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1459866251}
+    - targetCorrespondingSourceObject: {fileID: 3051756840367345086, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1491039586}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+--- !u!4 &1277443951 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3051756840367345086, guid: d8d6fa87f418254468a225b5b08ffc14, type: 3}
+  m_PrefabInstance: {fileID: 1277443950}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1284415042 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1284415044
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1284415042}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1285430131 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1285430133
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285430131}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1287315919 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+  m_PrefabInstance: {fileID: 137689831}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1295681477 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1295681479
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1295681477}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1306832984
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1306832986}
+  - component: {fileID: 1306832985}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1306832985
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1306832984}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1306832986
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1306832984}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1306841974 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1306841976
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1306841974}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1334374571 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1334374573
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1334374571}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1334523456 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1334523461
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1334523456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1336056165 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1336056167
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336056165}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1338112412 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1338112414
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338112412}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1338473221 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1338473223
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1338473221}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1344121573 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1344121578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1344121573}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1350802900 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1350802902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1350802900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1357584890 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1357584892
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1357584890}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1359557736
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1359557739}
+  - component: {fileID: 1359557738}
+  - component: {fileID: 1359557737}
+  m_Layer: 0
+  m_Name: Bush (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!54 &1359557737
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359557736}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!64 &1359557738
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359557736}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 0}
+--- !u!4 &1359557739
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1359557736}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.000000021855694, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -10.509998, y: 0, z: 6.38}
+  m_LocalScale: {x: 0.4055907, y: 0.5944337, z: 0.42303768}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 173166957}
+  - {fileID: 409427509}
+  - {fileID: 131656970}
+  - {fileID: 1821250549}
+  - {fileID: 1958531968}
+  - {fileID: 1249553222}
+  - {fileID: 155999779}
+  m_Father: {fileID: 727712894}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1361825543
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1064279168}
+    m_Modifications:
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3424341070634194018, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Nomal (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3424341070634194018, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+--- !u!4 &1361825544 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+  m_PrefabInstance: {fileID: 1361825543}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1377413118 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1377413120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1377413118}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1383522169
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1383522170}
+  m_Layer: 0
+  m_Name: Waters
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1383522170
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1383522169}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 521044214}
+  - {fileID: 1287315919}
+  m_Father: {fileID: 86917355}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1388160616 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1388160618
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1388160616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1388692998 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1388693000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1388692998}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1389379182
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1389379183}
+  m_Layer: 0
+  m_Name: -------------------Canvas------------------------------------ (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1389379183
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1389379182}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -25.952244, y: -1.6384783, z: 12.257519}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1392733670 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1392733672
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1392733670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1402935904 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1402935906
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1402935904}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1408691965 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1408691967
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1408691965}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1416440029 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1416440034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1416440029}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1417335661 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1417335663
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417335661}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1434082385 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1434082387
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1434082385}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1435972898
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1435972899}
+  m_Layer: 0
+  m_Name: -------------------StageData--------------------------------- (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1435972899
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1435972898}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -25.952244, y: -1.6384783, z: 12.257519}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1444064756 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1444064758
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1444064756}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1450552052 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1450552054
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1450552052}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1454368006
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1454368007}
+  - component: {fileID: 1454368011}
+  - component: {fileID: 1454368010}
+  - component: {fileID: 1454368009}
+  - component: {fileID: 1454368008}
+  m_Layer: 0
+  m_Name: Tree_02_C_green (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1454368007
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1454368006}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 375386724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1454368008
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1454368006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &1454368009
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1454368006}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: a65af00dd0d50914597a9d60ca2b6c9f, type: 3}
+--- !u!23 &1454368010
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1454368006}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1454368011
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1454368006}
+  m_Mesh: {fileID: 4300000, guid: a65af00dd0d50914597a9d60ca2b6c9f, type: 3}
+--- !u!1001 &1459866250
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1277443951}
+    m_Modifications:
+    - target: {fileID: 4859231402296104760, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Elite
+      objectReference: {fileID: 0}
+    - target: {fileID: 4859231402296104760, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6970393878450646207, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6970393878450646207, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6970393878450646207, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6970393878450646207, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6970393878450646207, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6970393878450646207, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6970393878450646207, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6970393878450646207, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6970393878450646207, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6970393878450646207, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+--- !u!4 &1459866251 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6970393878450646207, guid: 2344bbf5571f2b54188be9be8bfdc4a3, type: 3}
+  m_PrefabInstance: {fileID: 1459866250}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1464383953 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1464383955
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1464383953}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1472546305 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1472546307
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1472546305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1480871599 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1480871601
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1480871599}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1490652049 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1490652051
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1490652049}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1491039585
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1277443951}
+    m_Modifications:
+    - target: {fileID: 2696966804512784325, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Boss
+      objectReference: {fileID: 0}
+    - target: {fileID: 2696966804512784325, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462143003246491102, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462143003246491102, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462143003246491102, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462143003246491102, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462143003246491102, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462143003246491102, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462143003246491102, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462143003246491102, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462143003246491102, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3462143003246491102, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+--- !u!4 &1491039586 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3462143003246491102, guid: eecb9f0f63807a64ca426735536df706, type: 3}
+  m_PrefabInstance: {fileID: 1491039585}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1491728133 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1491728138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1491728133}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1496302679 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1496302681
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1496302679}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1502025192 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1502025194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1502025192}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1503910100
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1830543}
+    m_Modifications:
+    - target: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Name
+      value: Cube (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.58324414
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.750242
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13.490021
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.0025624118
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9999967
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -180.294
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2063818294}
+    - targetCorrespondingSourceObject: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 278408976}
+    - targetCorrespondingSourceObject: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1841160253}
+    - targetCorrespondingSourceObject: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 294486616}
+    - targetCorrespondingSourceObject: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 908584379}
+    - targetCorrespondingSourceObject: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 453827226}
+    - targetCorrespondingSourceObject: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 19901554}
+    - targetCorrespondingSourceObject: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1496302681}
+    - targetCorrespondingSourceObject: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 114653804}
+    - targetCorrespondingSourceObject: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 339861252}
+    - targetCorrespondingSourceObject: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2009457579}
+    - targetCorrespondingSourceObject: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 217738222}
+    - targetCorrespondingSourceObject: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1464383955}
+    - targetCorrespondingSourceObject: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 944469400}
+    - targetCorrespondingSourceObject: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 476898569}
+    - targetCorrespondingSourceObject: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1336056167}
+    - targetCorrespondingSourceObject: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1880354795}
+    - targetCorrespondingSourceObject: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 461893774}
+    - targetCorrespondingSourceObject: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 56232176}
+    - targetCorrespondingSourceObject: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1388160618}
+    - targetCorrespondingSourceObject: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1306841976}
+    - targetCorrespondingSourceObject: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2083298614}
+    - targetCorrespondingSourceObject: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1910774357}
+    - targetCorrespondingSourceObject: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 202533514}
+    - targetCorrespondingSourceObject: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1199489281}
+    - targetCorrespondingSourceObject: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 39969929}
+    - targetCorrespondingSourceObject: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 236876469}
+    - targetCorrespondingSourceObject: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 348908959}
+    - targetCorrespondingSourceObject: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 606879452}
+    - targetCorrespondingSourceObject: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 320072709}
+    - targetCorrespondingSourceObject: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1570302711}
+    - targetCorrespondingSourceObject: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1020362964}
+    - targetCorrespondingSourceObject: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1837846645}
+    - targetCorrespondingSourceObject: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1195454623}
+    - targetCorrespondingSourceObject: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1502025194}
+    - targetCorrespondingSourceObject: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 448357960}
+    - targetCorrespondingSourceObject: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 220526736}
+    - targetCorrespondingSourceObject: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1974300341}
+    - targetCorrespondingSourceObject: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1444064758}
+    - targetCorrespondingSourceObject: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 425844091}
+    - targetCorrespondingSourceObject: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 201220579}
+    - targetCorrespondingSourceObject: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 355910978}
+    - targetCorrespondingSourceObject: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1917304688}
+    - targetCorrespondingSourceObject: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1859098697}
+    - targetCorrespondingSourceObject: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 336677113}
+    - targetCorrespondingSourceObject: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1963086486}
+    - targetCorrespondingSourceObject: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 778460768}
+    - targetCorrespondingSourceObject: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1821562566}
+  m_SourcePrefab: {fileID: 100100000, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+--- !u!1 &1504038858 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1504038860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1504038858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1510791360 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4715424937290609186, guid: 049e4d1417108c44a8f128e7378a1a29, type: 3}
+  m_PrefabInstance: {fileID: 135299586}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c436aae1d78cbde40820698fc4915d88, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1520359635 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1520359637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1520359635}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1527387962 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1527387964
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1527387962}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1542941945 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1542941947
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1542941945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1545075228 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5803792039844301405, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+  m_PrefabInstance: {fileID: 7403202769893642368}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1567399006 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1567399011
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1567399006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1570302709 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1570302711
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1570302709}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1581366017 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1581366019
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1581366017}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1591734591 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1591734596
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1591734591}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1602744630 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1602744632
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1602744630}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1603174699 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1603174701
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1603174699}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1611855841 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1611855843
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1611855841}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1631178936 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1631178938
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1631178936}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1631229159 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1631229161
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1631229159}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1647838722 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1647838724
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1647838722}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1656251961 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1656251963
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1656251961}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1667527195
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1830543}
+    m_Modifications:
+    - target: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Name
+      value: Cube (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.58324414
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.7425594
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.989992
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.0025624118
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9999967
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -180.294
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 340744799}
+    - targetCorrespondingSourceObject: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1926564432}
+    - targetCorrespondingSourceObject: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1882607264}
+    - targetCorrespondingSourceObject: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2050811448}
+    - targetCorrespondingSourceObject: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2070504780}
+    - targetCorrespondingSourceObject: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1417335663}
+    - targetCorrespondingSourceObject: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2042521546}
+    - targetCorrespondingSourceObject: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 366121163}
+    - targetCorrespondingSourceObject: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1631178938}
+    - targetCorrespondingSourceObject: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1945883202}
+    - targetCorrespondingSourceObject: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 405706208}
+    - targetCorrespondingSourceObject: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1338473223}
+    - targetCorrespondingSourceObject: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 49415261}
+    - targetCorrespondingSourceObject: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 606724851}
+    - targetCorrespondingSourceObject: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2138380652}
+    - targetCorrespondingSourceObject: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1208004377}
+    - targetCorrespondingSourceObject: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 109317922}
+    - targetCorrespondingSourceObject: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 26956696}
+    - targetCorrespondingSourceObject: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1680506114}
+    - targetCorrespondingSourceObject: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1054737039}
+    - targetCorrespondingSourceObject: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1434082387}
+    - targetCorrespondingSourceObject: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2141409015}
+    - targetCorrespondingSourceObject: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 144328338}
+    - targetCorrespondingSourceObject: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1234459498}
+    - targetCorrespondingSourceObject: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 436608704}
+    - targetCorrespondingSourceObject: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1765007267}
+    - targetCorrespondingSourceObject: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2069320467}
+    - targetCorrespondingSourceObject: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 465112851}
+    - targetCorrespondingSourceObject: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1808994997}
+    - targetCorrespondingSourceObject: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1847561521}
+    - targetCorrespondingSourceObject: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1602744632}
+    - targetCorrespondingSourceObject: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 273418948}
+    - targetCorrespondingSourceObject: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 177335062}
+    - targetCorrespondingSourceObject: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1981347369}
+    - targetCorrespondingSourceObject: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 686619906}
+    - targetCorrespondingSourceObject: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1799237429}
+    - targetCorrespondingSourceObject: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1388693000}
+    - targetCorrespondingSourceObject: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 680445072}
+    - targetCorrespondingSourceObject: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1810177692}
+    - targetCorrespondingSourceObject: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2076721486}
+    - targetCorrespondingSourceObject: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1480871601}
+    - targetCorrespondingSourceObject: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1091589897}
+    - targetCorrespondingSourceObject: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 794295620}
+    - targetCorrespondingSourceObject: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 250981186}
+    - targetCorrespondingSourceObject: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1177283800}
+    - targetCorrespondingSourceObject: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 676908587}
+    - targetCorrespondingSourceObject: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 489129114}
+    - targetCorrespondingSourceObject: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 945686796}
+  m_SourcePrefab: {fileID: 100100000, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+--- !u!1 &1670287616 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1670287618
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1670287616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1679516247 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1679516249
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1679516247}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1680506112 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1680506114
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1680506112}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1687041027 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1687041029
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1687041027}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1694086350 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1694086352
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1694086350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1705123479
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 732578495}
+    m_Modifications:
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3424341070634194018, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_Name
+      value: Enemy_Nomal
+      objectReference: {fileID: 0}
+    - target: {fileID: 3424341070634194018, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+--- !u!4 &1705123480 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2627946796999697193, guid: 42d3ca1b3a3316b42aeac7d2276f5eb7, type: 3}
+  m_PrefabInstance: {fileID: 1705123479}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1721288476
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1721288477}
+  m_Layer: 0
+  m_Name: -------------------Lights------------------------------------ (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1721288477
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1721288476}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -25.952244, y: -1.6384783, z: 12.257519}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1724333138 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1724333140
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1724333138}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1741374956 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1741374958
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1741374956}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1744574637 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1744574639
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1744574637}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1751692264 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1751692269
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1751692264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1765007265 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1765007267
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1765007265}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1799237427 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1799237429
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1799237427}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1804384838 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1804384840
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1804384838}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1808994995 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1808994997
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1808994995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1810177690 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1810177692
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1810177690}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1817862599
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1817862600}
+  - component: {fileID: 1817862604}
+  - component: {fileID: 1817862603}
+  - component: {fileID: 1817862602}
+  - component: {fileID: 1817862601}
+  m_Layer: 0
+  m_Name: Tree_01A_green
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1817862600
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1817862599}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.1220365, y: 0.12575856, z: -0.46178818}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 375386724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1817862601
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1817862599}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &1817862602
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1817862599}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: df5432032005a9841805d87229b85473, type: 3}
+--- !u!23 &1817862603
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1817862599}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1817862604
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1817862599}
+  m_Mesh: {fileID: 4300000, guid: df5432032005a9841805d87229b85473, type: 3}
+--- !u!1 &1821250548
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1821250549}
+  - component: {fileID: 1821250553}
+  - component: {fileID: 1821250552}
+  - component: {fileID: 1821250551}
+  - component: {fileID: 1821250550}
+  m_Layer: 0
+  m_Name: Tree_01C_green
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1821250549
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1821250548}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -1.5384417, y: 0.12575848, z: -2.449257}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1359557739}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1821250550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1821250548}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &1821250551
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1821250548}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: 21a3ee2ce2de7304981687f9d4b8dd9a, type: 3}
+--- !u!23 &1821250552
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1821250548}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1821250553
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1821250548}
+  m_Mesh: {fileID: 4300000, guid: 21a3ee2ce2de7304981687f9d4b8dd9a, type: 3}
+--- !u!1 &1821562564 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1821562566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1821562564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1823240090 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1823240095
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1823240090}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1823966183 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1823966185
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1823966183}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1826557432 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1826557434
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1826557432}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1830804820 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1830804822
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1830804820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1837846643 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1837846645
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1837846643}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1841160251 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1841160253
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841160251}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1841226311 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1841226316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1841226311}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1847561519 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1847561521
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1847561519}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1859098695 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1859098697
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1859098695}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1864198625 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1864198630
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1864198625}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1867091334
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1867091335}
+  m_Layer: 0
+  m_Name: -------------------GameObjects------------------------------------ (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1867091335
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1867091334}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -25.952244, y: -1.6384783, z: 12.257519}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1870203762 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1870203764
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1870203762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1879780897 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1879780902
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1879780897}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1880354793 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1880354795
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1880354793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1882607262 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1882607264
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1882607262}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1901508735
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1901508736}
+  m_Layer: 0
+  m_Name: -------------------Environment------------------------------------ (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1901508736
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1901508735}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -25.952244, y: -1.6384783, z: 12.257519}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1908735005 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1908735007
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1908735005}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1910774355 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1910774357
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1910774355}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1913773387 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1913773389
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1913773387}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1917304686 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1917304688
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1917304686}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1919286092
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1830543}
+    m_Modifications:
+    - target: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Name
+      value: Cube (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.58324414
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.7451305
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 14.490021
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.0025624118
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9999967
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -180.294
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2043449649}
+    - targetCorrespondingSourceObject: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 609362696}
+    - targetCorrespondingSourceObject: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1957310161}
+    - targetCorrespondingSourceObject: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1260188707}
+    - targetCorrespondingSourceObject: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2125058196}
+    - targetCorrespondingSourceObject: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1823966185}
+    - targetCorrespondingSourceObject: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1679516249}
+    - targetCorrespondingSourceObject: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1134478287}
+    - targetCorrespondingSourceObject: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2094909987}
+    - targetCorrespondingSourceObject: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1357584892}
+    - targetCorrespondingSourceObject: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1870203764}
+    - targetCorrespondingSourceObject: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2070450831}
+    - targetCorrespondingSourceObject: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 457636759}
+    - targetCorrespondingSourceObject: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1140824663}
+    - targetCorrespondingSourceObject: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1490652051}
+    - targetCorrespondingSourceObject: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 15471686}
+    - targetCorrespondingSourceObject: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2112139449}
+    - targetCorrespondingSourceObject: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 201517050}
+    - targetCorrespondingSourceObject: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 964436540}
+    - targetCorrespondingSourceObject: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1472546307}
+    - targetCorrespondingSourceObject: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 681259408}
+    - targetCorrespondingSourceObject: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 268745206}
+    - targetCorrespondingSourceObject: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 152893804}
+    - targetCorrespondingSourceObject: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 586918737}
+    - targetCorrespondingSourceObject: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1946781129}
+    - targetCorrespondingSourceObject: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 684079343}
+    - targetCorrespondingSourceObject: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1402935906}
+    - targetCorrespondingSourceObject: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1908735007}
+    - targetCorrespondingSourceObject: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 655319963}
+    - targetCorrespondingSourceObject: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1450552054}
+    - targetCorrespondingSourceObject: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1005789510}
+    - targetCorrespondingSourceObject: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 586059381}
+    - targetCorrespondingSourceObject: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 822607997}
+    - targetCorrespondingSourceObject: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2014490411}
+    - targetCorrespondingSourceObject: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1295681479}
+    - targetCorrespondingSourceObject: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1830804822}
+    - targetCorrespondingSourceObject: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1041165221}
+    - targetCorrespondingSourceObject: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1631229161}
+    - targetCorrespondingSourceObject: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 370590322}
+    - targetCorrespondingSourceObject: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 891083719}
+    - targetCorrespondingSourceObject: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 426295421}
+    - targetCorrespondingSourceObject: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1504038860}
+    - targetCorrespondingSourceObject: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1176286882}
+    - targetCorrespondingSourceObject: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1520359637}
+    - targetCorrespondingSourceObject: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1338112414}
+    - targetCorrespondingSourceObject: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1377413120}
+    - targetCorrespondingSourceObject: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1032074061}
+    - targetCorrespondingSourceObject: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2006735559}
+  m_SourcePrefab: {fileID: 100100000, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+--- !u!1 &1926564430 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1926564432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1926564430}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1945883200 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1945883202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1945883200}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1946781127 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1946781129
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1946781127}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1947961113
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1947961114}
+  - component: {fileID: 1947961118}
+  - component: {fileID: 1947961117}
+  - component: {fileID: 1947961116}
+  - component: {fileID: 1947961115}
+  m_Layer: 0
+  m_Name: Tree_02_C_green
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1947961114
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947961113}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.7063348, y: 0, z: -3.3075886}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 375386724}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1947961115
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947961113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &1947961116
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947961113}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: a65af00dd0d50914597a9d60ca2b6c9f, type: 3}
+--- !u!23 &1947961117
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947961113}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1947961118
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1947961113}
+  m_Mesh: {fileID: 4300000, guid: a65af00dd0d50914597a9d60ca2b6c9f, type: 3}
+--- !u!1 &1957310159 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1957310161
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1957310159}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1958531967
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1958531968}
+  - component: {fileID: 1958531972}
+  - component: {fileID: 1958531971}
+  - component: {fileID: 1958531970}
+  - component: {fileID: 1958531969}
+  m_Layer: 0
+  m_Name: Tree_01A_green
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1958531968
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1958531967}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.1220365, y: 0.12575856, z: -0.46178818}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1359557739}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1958531969
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1958531967}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bd17d19d9f8874aaa9885a4ba554b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!64 &1958531970
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1958531967}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 5
+  m_Convex: 1
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 4300000, guid: df5432032005a9841805d87229b85473, type: 3}
+--- !u!23 &1958531971
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1958531967}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e348b41cb0a07d64a8b3214d32d14a46, type: 2}
+  - {fileID: 2100000, guid: 0a0e46dd7f740934b8a931e01131bbb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1958531972
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1958531967}
+  m_Mesh: {fileID: 4300000, guid: df5432032005a9841805d87229b85473, type: 3}
+--- !u!1 &1963086484 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1963086486
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1963086484}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1968078032 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1968078034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1968078032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1974300339 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1974300341
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1974300339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1980670379 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1980670381
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1980670379}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1981347367 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1981347369
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1981347367}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1987581166 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1987581168
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1987581166}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &1991047052
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1830543}
+    m_Modifications:
+    - target: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Name
+      value: Cube (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.58324414
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4.7528133
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 12.990021
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.0025624118
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.9999967
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: -180.294
+      objectReference: {fileID: 0}
+    - target: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 608592860}
+    - targetCorrespondingSourceObject: {fileID: 3352729380607988906, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 168441522}
+    - targetCorrespondingSourceObject: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1039133501}
+    - targetCorrespondingSourceObject: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1670287618}
+    - targetCorrespondingSourceObject: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1077291463}
+    - targetCorrespondingSourceObject: {fileID: 297777940480553226, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 211253440}
+    - targetCorrespondingSourceObject: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1152598421}
+    - targetCorrespondingSourceObject: {fileID: 2433417417910249646, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 71629818}
+    - targetCorrespondingSourceObject: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1350802902}
+    - targetCorrespondingSourceObject: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1392733672}
+    - targetCorrespondingSourceObject: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 56131056}
+    - targetCorrespondingSourceObject: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 464123733}
+    - targetCorrespondingSourceObject: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1980670381}
+    - targetCorrespondingSourceObject: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1993657322}
+    - targetCorrespondingSourceObject: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2104275130}
+    - targetCorrespondingSourceObject: {fileID: 2570331190192026340, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 387930813}
+    - targetCorrespondingSourceObject: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2020542121}
+    - targetCorrespondingSourceObject: {fileID: 1393027331950942371, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1527387964}
+    - targetCorrespondingSourceObject: {fileID: 1889690736816269671, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1104505219}
+    - targetCorrespondingSourceObject: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 113062991}
+    - targetCorrespondingSourceObject: {fileID: 5527733334915771801, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 489151522}
+    - targetCorrespondingSourceObject: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2078024500}
+    - targetCorrespondingSourceObject: {fileID: 3313694498815639754, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 116927227}
+    - targetCorrespondingSourceObject: {fileID: 3572940977915484234, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1016390325}
+    - targetCorrespondingSourceObject: {fileID: 8600572747319796660, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1215683862}
+    - targetCorrespondingSourceObject: {fileID: 2956258906867476230, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 39841990}
+    - targetCorrespondingSourceObject: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2128118227}
+    - targetCorrespondingSourceObject: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 529359644}
+    - targetCorrespondingSourceObject: {fileID: 6182226011975951228, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 420117848}
+    - targetCorrespondingSourceObject: {fileID: 7009906990235320649, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1913773389}
+    - targetCorrespondingSourceObject: {fileID: 5207360437909963820, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1012641265}
+    - targetCorrespondingSourceObject: {fileID: 5970671563975690764, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 371328099}
+    - targetCorrespondingSourceObject: {fileID: 7021300887328153028, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1229211283}
+    - targetCorrespondingSourceObject: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1042154318}
+    - targetCorrespondingSourceObject: {fileID: 5081324792368683682, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 496433316}
+    - targetCorrespondingSourceObject: {fileID: 448352221203144824, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 447259180}
+    - targetCorrespondingSourceObject: {fileID: 6628924709470140994, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1611855843}
+    - targetCorrespondingSourceObject: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1047771937}
+    - targetCorrespondingSourceObject: {fileID: 6790432701666432481, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1744574639}
+    - targetCorrespondingSourceObject: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 244226514}
+    - targetCorrespondingSourceObject: {fileID: 3479939132149822509, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 345588950}
+    - targetCorrespondingSourceObject: {fileID: 2926939024143971391, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 597641510}
+    - targetCorrespondingSourceObject: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2088940329}
+    - targetCorrespondingSourceObject: {fileID: 4687680662436543614, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1096514247}
+    - targetCorrespondingSourceObject: {fileID: 7559535740133272479, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 808513581}
+    - targetCorrespondingSourceObject: {fileID: 3818997194794147363, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 662640550}
+    - targetCorrespondingSourceObject: {fileID: 7548379087361116738, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1741374958}
+    - targetCorrespondingSourceObject: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 975791744}
+  m_SourcePrefab: {fileID: 100100000, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+--- !u!1 &1993657320 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7168459068657386283, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1993657322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1993657320}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2004079139 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8235464452430477337, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2004079144
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2004079139}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2006735557 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6514245132281911596, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2006735559
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2006735557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2009457577 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6732972608538703305, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2009457579
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2009457577}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2014490409 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2014490411
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2014490409}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2020542119 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2020542121
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2020542119}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2041736581 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 40688257412330428, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2041736586
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2041736581}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2042521544 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2042521546
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2042521544}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2043449648 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2043449649
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2043449648}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &2043449653 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2050811446 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3679070894088264706, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2050811448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2050811446}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2063818293 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 269072302513123437, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2063818294
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2063818293}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &2063818298 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2336263352729347563, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2069320465 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2069320467
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2069320465}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2069778961 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 853060642426479955, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2069778966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2069778961}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2070450829 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1285889485815974883, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2070450831
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2070450829}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2070504778 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2070504780
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2070504778}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2076721484 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 228334822429451160, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2076721486
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2076721484}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2077290438 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8261659298046185811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2077290443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2077290438}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2078024498 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2078024500
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2078024498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2083298612 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1503910100}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2083298614
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2083298612}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2088940327 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3671763577078865070, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2088940329
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2088940327}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2089715763 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8991253433151640502, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2089715765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2089715763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2094909985 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4764057896163008427, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2094909987
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2094909985}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2097790034 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2168446724849848580, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2097790036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2097790034}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2104275128 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2104275130
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2104275128}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2112139447 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7737510417102480527, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2112139449
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2112139447}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2114281321
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2114281322}
+  m_Layer: 0
+  m_Name: -------------------Managers------------------------------------ (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2114281322
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2114281321}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -25.952244, y: -1.6384783, z: 12.257519}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2119440233 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6950433874603255811, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 459247438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2119440238
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2119440233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2125058194 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6937958631693863539, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1919286092}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2125058196
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2125058194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2128118225 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5274811803575281103, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1991047052}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2128118227
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2128118225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2137624346
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2137624349}
+  - component: {fileID: 2137624348}
+  - component: {fileID: 2137624347}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &2137624347
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2137624346}
+  m_Enabled: 1
+--- !u!20 &2137624348
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2137624346}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &2137624349
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2137624346}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.70710665, y: -0.00000010430813, z: 0.000000063329935, w: 0.7071069}
+  m_LocalPosition: {x: -2.593315, y: 14.079397, z: 16.285412}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2138380650 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5771333586495166416, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2138380652
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2138380650}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2141409013 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3070441445488196735, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 1667527195}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2141409015
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2141409013}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &2144548911 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8555309940536392800, guid: 62bd48fc4f75b774198f4b3fc24e3a38, type: 3}
+  m_PrefabInstance: {fileID: 45324381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2144548913
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2144548911}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 75ce8d23a416ec34486f08cb4ef0f91d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &2507980923612088714
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1383522170}
+    m_Modifications:
+    - target: {fileID: 8753660031007213736, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_Name
+      value: ToonWater - Water - Solid 800Tris
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13.32
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.100000024
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 10.81
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.70710677
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 8753660031007708296, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d294187d8fc92504885dc7b847e43134, type: 3}
+--- !u!1001 &7403202769893642368
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 727712894}
+    m_Modifications:
+    - target: {fileID: 1468403817041549561, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+      propertyPath: m_Name
+      value: Bush
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803792039844301405, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.372398
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803792039844301405, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803792039844301405, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803792039844301405, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803792039844301405, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.000000021855694
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803792039844301405, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803792039844301405, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803792039844301405, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803792039844301405, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5803792039844301405, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9184c6ad6bcbca045a6155bc0f095596, type: 3}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1435972899}
+  - {fileID: 640304340}
+  - {fileID: 289862198}
+  - {fileID: 2137624349}
+  - {fileID: 1721288477}
+  - {fileID: 1306832986}
+  - {fileID: 1389379183}
+  - {fileID: 1901508736}
+  - {fileID: 86917355}
+  - {fileID: 968996776}
+  - {fileID: 1867091335}
+  - {fileID: 490486336}
+  - {fileID: 135299586}
+  - {fileID: 732578494}
+  - {fileID: 1277443950}
+  - {fileID: 1064279167}
+  - {fileID: 2114281322}
+  - {fileID: 905757903}
+  - {fileID: 844969852}

--- a/Assets/01_CJM_EnemyAndStageManager/Scenes/CJM_ProtoType-TestScene.unity.meta
+++ b/Assets/01_CJM_EnemyAndStageManager/Scenes/CJM_ProtoType-TestScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 643727e0a5bd0554b9bad1c49e0a3f49
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/01_CJM_EnemyAndStageManager/Scripts/Enemy/Enemy.cs
+++ b/Assets/01_CJM_EnemyAndStageManager/Scripts/Enemy/Enemy.cs
@@ -75,8 +75,6 @@ public class Enemy : MonoBehaviour, IDamagable
 
     public void TakeDamage()
     {
-        Debug.Log("공격받음");
-
         hp -= 1;
         if (hp <= 0) Dead();
     }

--- a/Assets/01_CJM_EnemyAndStageManager/Scripts/Enemy/EnemySpawner.cs
+++ b/Assets/01_CJM_EnemyAndStageManager/Scripts/Enemy/EnemySpawner.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class EnemySpawner : MonoBehaviour, IDamagable
+public class EnemySpawner : MonoBehaviour
 {
     [SerializeField] private SpawnerState state;
     [SerializeField] private Transform standByGroup;
@@ -49,16 +49,8 @@ public class EnemySpawner : MonoBehaviour, IDamagable
         }
     }
 
-    public void TakeDamage() 
-    {
-        // 어차피 콜라이더 없어서 직접적인 충돌은 없고
-        // 자식 오브젝트로 들어갈 Enemy들의 Damagable을 전달하는 방식
-        IDamagable damagable = standByGroup.GetChild(0).gameObject.GetComponent<Enemy>();
-        damagable?.TakeDamage();
-    }
-
     // TODO:
-    // 콜라이더로 스포너 영역 내 적/플레이어 탱크 들어오면 스폰 불가 상태로 변경
+    // 콜라이더로 스포너 영역 내 적/플레이어 탱크 들어오면 스폰 불가 상태로 변경? 필요하면 추가
     // 스포너 영역 내 아무도 없으면 스폰가능 상태로 변경
 }
 

--- a/Assets/01_CJM_EnemyAndStageManager/Scripts/Player/DamageToRoot.cs
+++ b/Assets/01_CJM_EnemyAndStageManager/Scripts/Player/DamageToRoot.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Data;
+using UnityEngine;
+
+public class DamageToParent : MonoBehaviour, IDamagable
+{
+    enum ParentType { Parent, Root }
+    [SerializeField] ParentType type;
+    public void TakeDamage()
+    {
+        if (type == ParentType.Parent)
+            transform.parent.GetComponent<IDamagable>().TakeDamage();
+        else if (type == ParentType.Root)
+            transform.root.GetComponent<IDamagable>().TakeDamage();
+
+    }
+}

--- a/Assets/01_CJM_EnemyAndStageManager/Scripts/Player/DamageToRoot.cs.meta
+++ b/Assets/01_CJM_EnemyAndStageManager/Scripts/Player/DamageToRoot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb16f5c3562c5244c90cdcaecddbf8c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/01_CJM_EnemyAndStageManager/Scripts/Player/Player.cs
+++ b/Assets/01_CJM_EnemyAndStageManager/Scripts/Player/Player.cs
@@ -138,7 +138,7 @@ public class Player : MonoBehaviour, IDamagable
 
         // 플레이어 위치 이동 & 정지
         playerController.transform.position = respawnPoint.gameObject.transform.position;
-        playerController.transform.rotation = respawnPoint.gameObject.transform.rotation;
+        playerController.Body.transform.forward = respawnPoint.gameObject.transform.forward;
         playerController.dir = Vector3.zero;
 
         Debug.Log(respawnPoint.gameObject.transform.position);

--- a/Assets/01_CJM_EnemyAndStageManager/Scripts/Player/PlayerController.cs
+++ b/Assets/01_CJM_EnemyAndStageManager/Scripts/Player/PlayerController.cs
@@ -7,6 +7,7 @@ public class PlayerController : MonoBehaviour
 {
     [SerializeField] Transform muzzPoint;
     [SerializeField] Transform body;
+    public Transform Body { get { return body; } }
 
     private Player player;
     private Rigidbody rb;


### PR DESCRIPTION
- 플레이어와 적 데미지 받는 로직 변화 (콜라이더를 보유한 자식 객체에 DamageToRoot에서 부모 위치에 메인 IDamagable로 함수 넘겨주는 방식으로 변경)
- 적과 플레이어 프리펩에 수정사항 반영 (Outline 컴포넌트 추가, DamageToRoot컴포넌트 추가)

참고 : [Fix] PooledObject 스크립트 변경사항 요청 #94